### PR TITLE
new: Add CLI for seeding the database

### DIFF
--- a/app/api/db/index.ts
+++ b/app/api/db/index.ts
@@ -18,14 +18,11 @@ export const connectionOptions: DataSourceOptions = {
 
 const db = new DataSource(connectionOptions);
 
-let dbInitialized = false;
-
 async function getDb() {
   noStore();
 
-  if (!dbInitialized) {
+  if (!db.isInitialized) {
     await db.initialize();
-    dbInitialized = true;
   }
 
   return db;

--- a/app/api/db/seed.ts
+++ b/app/api/db/seed.ts
@@ -1,0 +1,182 @@
+import { Option, program } from "@commander-js/extra-typings";
+import { faker } from "@faker-js/faker";
+import { randomUUID } from "crypto";
+import { config } from "dotenv";
+import path from "path";
+import { DataSource, DataSourceOptions } from "typeorm";
+import { SnakeNamingStrategy } from "typeorm-naming-strategies";
+import { getAllowedVersions } from "../(utils)";
+import { getTags } from "../tags";
+import { Email, Module, Notification, Rank, Release, User } from "./entities";
+
+config({ path: path.resolve(process.cwd(), ".env.local") });
+
+function createUser(): User {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+
+  const user = new User();
+  user.email = faker.internet.email({ firstName, lastName });
+  user.emailVerified = faker.datatype.boolean(0.95);
+  user.id = randomUUID();
+  user.image = faker.image.avatar();
+  user.lastNameChangeTime = null;
+  user.modules = [];
+  user.name = faker.internet.userName({ firstName, lastName }).replace(".", "_");
+  user.notifications = [];
+  user.password = faker.internet.password();
+  user.passwordResetToken = null;
+  user.rank = Rank.DEFAULT;
+  user.verificationToken = null;
+
+  return user;
+}
+
+function createModule(): Module {
+  const module = new Module();
+  module.description = faker.lorem.paragraph();
+  module.downloads = 0;
+  module.hidden = false;
+  module.id = randomUUID();
+  module.image = faker.image.avatar(); // TODO
+  module.name = faker.lorem.word();
+  module.releases = [];
+  module.summary = faker.lorem.sentence();
+  module.tags = [];
+
+  return module;
+}
+
+function createRelease(): Release {
+  const release = new Release();
+  release.changelog = faker.lorem.sentences();
+  release.downloads = faker.number.int({ min: 0, max: 1e5 });
+  release.game_versions = [];
+  release.id = randomUUID();
+  release.release_version = faker.system.semver();
+  release.verified_at = null;
+  release.verified_by = null;
+
+  return release;
+}
+
+async function seed(db: DataSource, userCount: number, moduleCount: number, releaseCount: number) {
+  const users = faker.helpers.multiple(createUser, { count: userCount });
+
+  faker.helpers.arrayElements(users, 2).forEach(user => {
+    user.rank = Rank.TRUSTED;
+  });
+  faker.helpers.arrayElements(users, 1).forEach(user => {
+    user.rank = Rank.ADMIN;
+  });
+
+  const modules = faker.helpers.multiple(createModule, { count: moduleCount });
+
+  const releases: Release[] = [];
+
+  const tags = [...(await getTags())];
+  const {
+    default: { modVersions },
+  } = await getAllowedVersions();
+
+  modules.forEach(module => {
+    const user = faker.helpers.arrayElement(users);
+    module.user = user;
+    module.tags = faker.helpers.arrayElements(tags);
+
+    const moduleReleases = faker.helpers.multiple(createRelease, {
+      count: releaseCount,
+    });
+
+    moduleReleases.forEach(release => {
+      release.mod_version = faker.helpers.arrayElement(Object.keys(modVersions));
+      release.game_versions = modVersions[release.mod_version as keyof typeof modVersions];
+      release.verified = user.rank !== Rank.DEFAULT;
+      if (!release.verified) {
+        if (faker.datatype.boolean(0.8)) {
+          release.verified_at = faker.date.recent();
+          release.verified_by = faker.helpers.arrayElement(
+            users.filter(user => user.rank == Rank.ADMIN || user.rank == Rank.TRUSTED),
+          );
+          release.verified = true;
+        } else {
+          release.downloads = 0;
+        }
+      } else {
+        release.verified_at = faker.date.recent();
+        release.verified_by = user;
+      }
+
+      release.module = module;
+    });
+
+    releases.push(...moduleReleases);
+
+    module.downloads = moduleReleases.reduce((a, b) => a + b.downloads, 0);
+  });
+
+  await db.getRepository(User).save(users);
+  await db.getRepository(Module).save(modules);
+  await db.getRepository(Release).save(releases);
+}
+
+async function main() {
+  const prog = program
+    .name("seed")
+    .description("CLI utility to seed the database")
+    .version("0.0.1")
+    .addOption(new Option("-d, --drop", "drop the database before executing").default(false))
+    .addOption(
+      new Option("-u, --users <count>", "how many users to create")
+        .default(10)
+        .argParser(value => parseInt(value)),
+    )
+    .addOption(
+      new Option("-m, --modules <count>", "how many modules to create")
+        .default(20)
+        .argParser(value => parseInt(value)),
+    )
+    .addOption(
+      new Option("-r, --releases <count>", "how many releases created per module")
+        .default(10)
+        .argParser(value => parseInt(value)),
+    )
+    .parse();
+
+  const { users, modules, releases, drop } = prog.opts();
+
+  const connectionOptions: DataSourceOptions = {
+    type: "mysql",
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT!),
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+    entities: [Email, Module, Notification, Release, User],
+    namingStrategy: new SnakeNamingStrategy(),
+  };
+
+  const db = await new DataSource(connectionOptions).initialize();
+
+  if (drop) {
+    console.log("Dropping existing data...");
+  }
+  await db.synchronize(drop);
+  if (drop) {
+    console.log("Dropped existing data");
+  }
+
+  console.log(
+    "Seeding database with %d users, %d modules, %d releases per module...",
+    users,
+    modules,
+    releases,
+  );
+
+  await seed(db, Math.max(users, 1), Math.max(modules, 1), Math.max(releases, 1));
+  console.log("Seeding complete");
+
+  process.exit(0);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "tsx app/api/db/seed.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
@@ -33,7 +34,6 @@
     "marked": "^9.0.3",
     "marked-react": "^2.0.0",
     "monaco-editor": "^0.43.0",
-    "mysql": "^2.18.1",
     "mysql2": "^3.6.1",
     "next": "^14.0.4",
     "node-loader": "^2.0.0",
@@ -55,17 +55,22 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@commander-js/extra-typings": "^12.0.1",
+    "@faker-js/faker": "^8.4.1",
     "@next/eslint-plugin-next": "^13.5.4",
     "@types/node": "20.8.0",
     "@types/react": "18.2.23",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
+    "commander": "^12.0.0",
+    "dotenv": "^16.4.5",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.0.3",
+    "tsx": "^4.7.2",
     "typeorm-extension": "^3.0.2",
     "typescript": "^5.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,22 +57,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.20.7, @babel/runtime-corejs3@npm:^7.22.15, @babel/runtime-corejs3@npm:^7.24.1":
-  version: 7.24.1
-  resolution: "@babel/runtime-corejs3@npm:7.24.1"
+"@babel/runtime-corejs3@npm:^7.20.7, @babel/runtime-corejs3@npm:^7.22.15, @babel/runtime-corejs3@npm:^7.24.4":
+  version: 7.24.4
+  resolution: "@babel/runtime-corejs3@npm:7.24.4"
   dependencies:
     core-js-pure: ^3.30.2
     regenerator-runtime: ^0.14.0
-  checksum: 38d7f069440b222b62d1e73c3b9be4a52dd79da7ca5ee3ca032039927c08c1ebacd85fdb11a99d261ca48820362cef6099364db8ff4ed25d7a19777910c9f62b
+  checksum: 0c2e7c477de3dbf5cc6f2434cee3d78a34d87e8f1e2ea65840eb948d00f7d6968e0ef055449adf372a39d6214f8b9b2532506149b9d0e7ea3d09b1b84678ae6c
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
-  version: 7.24.1
-  resolution: "@babel/runtime@npm:7.24.1"
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+  version: 7.24.4
+  resolution: "@babel/runtime@npm:7.24.4"
   dependencies:
     regenerator-runtime: ^0.14.0
-  checksum: 5c8f3b912ba949865f03b3cf8395c60e1f4ebd1033fbd835bdfe81b6cac8a87d85bc3c7aded5fcdf07be044c9ab8c818f467abe0deca50020c72496782639572
+  checksum: 2f27d4c0ffac7ae7999ac0385e1106f2a06992a8bdcbf3da06adcac7413863cd08c198c2e4e970041bbea849e17f02e1df18875539b6afba76c781b6b59a07c3
   languageName: node
   linkType: hard
 
@@ -91,6 +91,15 @@ __metadata:
   version: 7.0.1
   resolution: "@braintree/sanitize-url@npm:7.0.1"
   checksum: 793a3b01c5e06152b197c73cccee2db99e921b36d944fc0738e732b5da068709da8844eb8e1489ea360c34b00a100c8b9b3065d5e2030ba5252cdd5d2a6a9a28
+  languageName: node
+  linkType: hard
+
+"@commander-js/extra-typings@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "@commander-js/extra-typings@npm:12.0.1"
+  peerDependencies:
+    commander: ~12.0.0
+  checksum: 2490d44c5046d94e73c5c65f8055522954855f7475e6d170d14a84a9e6235f28ac87d9b46d8e6ae8cc4268371937fba94953df5336547765bb87e94d59964eef
   languageName: node
   linkType: hard
 
@@ -319,6 +328,167 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/aix-ppc64@npm:0.19.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm64@npm:0.19.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm@npm:0.19.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-x64@npm:0.19.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-arm64@npm:0.19.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-x64@npm:0.19.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.19.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-x64@npm:0.19.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm64@npm:0.19.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm@npm:0.19.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ia32@npm:0.19.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-loong64@npm:0.19.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-mips64el@npm:0.19.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ppc64@npm:0.19.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-riscv64@npm:0.19.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-s390x@npm:0.19.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-x64@npm:0.19.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/netbsd-x64@npm:0.19.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/openbsd-x64@npm:0.19.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/sunos-x64@npm:0.19.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-arm64@npm:0.19.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-ia32@npm:0.19.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-x64@npm:0.19.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -531,14 +701,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/base@npm:5.0.0-beta.41, @mui/base@npm:^5.0.0-beta.20":
-  version: 5.0.0-beta.41
-  resolution: "@mui/base@npm:5.0.0-beta.41"
+"@mui/base@npm:5.0.0-beta.42, @mui/base@npm:^5.0.0-beta.20":
+  version: 5.0.0-beta.42
+  resolution: "@mui/base@npm:5.0.0-beta.42"
   dependencies:
-    "@babel/runtime": ^7.23.9
+    "@babel/runtime": ^7.24.4
     "@floating-ui/react-dom": ^2.0.8
     "@mui/types": ^7.2.14
-    "@mui/utils": ^5.15.14
+    "@mui/utils": ^6.0.0-alpha.1
     "@popperjs/core": ^2.11.8
     clsx: ^2.1.0
     prop-types: ^15.8.1
@@ -549,27 +719,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 4813d5e5a4a991d44502339d5eb84c58d5beed1401f7c5200614cbf8e98b3c36d4e07f55b82e26c90a9f5b3fbfa16971305f39e4145e3db1ff2864a109dc6bb4
+  checksum: f7af6e6003a4a8502062607b7861490eb6dc3a1f617532c92521981329ae077535444d65e378718bbf59ce8b7a52fc32275dc794969c73bdb389e5d69155fc69
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^5.15.14":
-  version: 5.15.14
-  resolution: "@mui/core-downloads-tracker@npm:5.15.14"
-  checksum: 0a1c63d906af594d0a7fb63d1d574482b3916351ea8908e8621c8bfa16ac38cf4edb5a334f0e28084f583ac928b587cab6e031f992195e0a590186faba13b9a5
+"@mui/core-downloads-tracker@npm:^5.15.15":
+  version: 5.15.15
+  resolution: "@mui/core-downloads-tracker@npm:5.15.15"
+  checksum: 3e99a04e03f66d5fa5f0c23cdce0f9fa2331ba08c99a75dc2347ccaa1c6ed520153e04aaeb0d613c9dca099a3e6242558a6284c33d93f95cc65e3243b17860bc
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.0
-  resolution: "@mui/core-downloads-tracker@npm:6.0.0-alpha.0"
-  checksum: 90da6ae70b96d2a0dcd9eb16d2e2c4a397e70f2200b7c26c314ca5029abd6065210adb29a9ba74053586e4b1d9aeea433623eb76486ab07426790674de4bedec
+"@mui/core-downloads-tracker@npm:^6.0.0-alpha.2":
+  version: 6.0.0-alpha.2
+  resolution: "@mui/core-downloads-tracker@npm:6.0.0-alpha.2"
+  checksum: e52a4fa615f85586bcf09d8adbdc71976e923b2fb5a8786377bae6bd6912f9ac8f7551ec39915edd2b00c770f5a42d3868b8d8ef7f3f44b1e288bf2db00c4c38
   languageName: node
   linkType: hard
 
 "@mui/icons-material@npm:^5.14.11":
-  version: 5.15.14
-  resolution: "@mui/icons-material@npm:5.15.14"
+  version: 5.15.15
+  resolution: "@mui/icons-material@npm:5.15.15"
   dependencies:
     "@babel/runtime": ^7.23.9
   peerDependencies:
@@ -579,20 +749,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 719036244167c7cb5456074d7d66df0c26d4b200c11620ba177a4e75186f6ecc4930a3b4bcb7300d92aa37df19ca8406fa63ad4347214cc167ddca986eb1a198
+  checksum: 42d62fc94be25a361034a8974b1860608e866c155ff2eea7dc18f10a4acc71dbe2f48af3f0309a345ff6fb16be30c6fbc1d8a0a447c828aa1380a49e176a8803
   languageName: node
   linkType: hard
 
 "@mui/joy@npm:^5.0.0-beta.9":
-  version: 5.0.0-beta.33
-  resolution: "@mui/joy@npm:5.0.0-beta.33"
+  version: 5.0.0-beta.35
+  resolution: "@mui/joy@npm:5.0.0-beta.35"
   dependencies:
-    "@babel/runtime": ^7.23.9
-    "@mui/base": 5.0.0-beta.41
-    "@mui/core-downloads-tracker": ^6.0.0-alpha.0
-    "@mui/system": ^6.0.0-alpha.0
+    "@babel/runtime": ^7.24.4
+    "@mui/base": 5.0.0-beta.42
+    "@mui/core-downloads-tracker": ^6.0.0-alpha.2
+    "@mui/system": ^6.0.0-alpha.1
     "@mui/types": ^7.2.14
-    "@mui/utils": ^5.15.14
+    "@mui/utils": ^6.0.0-alpha.1
     clsx: ^2.1.0
     prop-types: ^15.8.1
   peerDependencies:
@@ -608,18 +778,18 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 8ab66bae9ef565791e336a89aa30820e5df822c696c8650a0c3fea019f5a3c77bd6a18d050b7ac87e14cafd9397ab31ced55c2376e744f74439d0d54a1a7dfe3
+  checksum: ecce14a918391095b239fc818dceebd35e49d3bc5b162dbf89e69043ae0bfefc1b8ed9ad28625308422b2d0bbc1e07b93b98e618bef9f6966b908e1fb4b92a34
   languageName: node
   linkType: hard
 
 "@mui/material@npm:^5.14.11":
-  version: 5.15.14
-  resolution: "@mui/material@npm:5.15.14"
+  version: 5.15.15
+  resolution: "@mui/material@npm:5.15.15"
   dependencies:
     "@babel/runtime": ^7.23.9
     "@mui/base": 5.0.0-beta.40
-    "@mui/core-downloads-tracker": ^5.15.14
-    "@mui/system": ^5.15.14
+    "@mui/core-downloads-tracker": ^5.15.15
+    "@mui/system": ^5.15.15
     "@mui/types": ^7.2.14
     "@mui/utils": ^5.15.14
     "@types/react-transition-group": ^4.4.10
@@ -641,7 +811,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 6105cea67d1a176bf4d360e4316760d761a92d9165a4aae76235c21927d6d72837d9272d9c8f14295393ce7c9bb8852cae7cb7cb4a2434118ce4e19165055625
+  checksum: ee0dc22fc4d617f7cf69f2451b6d5139978e6c5319e3056e7719159aff786ee3b80abd07691e230371811d9b5b574aef4559d7855bfe2f8493d596d960a91ab7
   languageName: node
   linkType: hard
 
@@ -659,6 +829,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 1b1ef54e8281c9b13fcc58f4c39682efc610946a68402283c19fcfbce8a7d7a231d61b536d6df9bf7a59a1426591bd403a453a59eb8efb9689437fb58554dc8c
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^6.0.0-alpha.1":
+  version: 6.0.0-alpha.1
+  resolution: "@mui/private-theming@npm:6.0.0-alpha.1"
+  dependencies:
+    "@babel/runtime": ^7.24.4
+    "@mui/utils": ^6.0.0-alpha.1
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 200effa655238f085c5e3d824f591ad926e1c03fcbfbc5bfbb2b6366efbafa3146791028c23c9d63769cfe3513ac76c560cf3a091efc949dec0596e9e678f4d4
   languageName: node
   linkType: hard
 
@@ -683,11 +870,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.0
-  resolution: "@mui/styled-engine@npm:6.0.0-alpha.0"
+"@mui/styled-engine@npm:^6.0.0-alpha.1":
+  version: 6.0.0-alpha.1
+  resolution: "@mui/styled-engine@npm:6.0.0-alpha.1"
   dependencies:
-    "@babel/runtime": ^7.23.9
+    "@babel/runtime": ^7.24.4
     "@emotion/cache": ^11.11.0
     csstype: ^3.1.3
     prop-types: ^15.8.1
@@ -700,13 +887,13 @@ __metadata:
       optional: true
     "@emotion/styled":
       optional: true
-  checksum: 095ed9f2a5a6fe4979f31912da530edf846b2e72a25065f1cc3831a6c271be60779b5c192b69f0f87dcca74b7ab67247b8da5019c161590cff5d5145c81f481a
+  checksum: 2c84b377c58b256d982525174a10eb5c812a86f9dacf69a386ec6f4bcdc099943d13dd2d1f97af063c554b579a0f95c106479423f2dcc58f5070de46d1e242d8
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^5.14.12, @mui/system@npm:^5.15.14":
-  version: 5.15.14
-  resolution: "@mui/system@npm:5.15.14"
+"@mui/system@npm:^5.14.12, @mui/system@npm:^5.15.15":
+  version: 5.15.15
+  resolution: "@mui/system@npm:5.15.15"
   dependencies:
     "@babel/runtime": ^7.23.9
     "@mui/private-theming": ^5.15.14
@@ -728,19 +915,19 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: bcc216274a99f5df9ef28551f0d4985e065ea55922307162d8877f828e136e50c8f3997241b3566668af3bd473a599a70f8d1becea81d5c052cc5defda5e0aac
+  checksum: 9ca96d5f66b2a9d6471909cc98c671eea5ec0a6d58a7ec071073b9e5200b95c3f017f0ca5cc946abc7f83074bd11830ca18f5e30bc98e25cd6ca217bd1b3a26f
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.0
-  resolution: "@mui/system@npm:6.0.0-alpha.0"
+"@mui/system@npm:^6.0.0-alpha.1":
+  version: 6.0.0-alpha.1
+  resolution: "@mui/system@npm:6.0.0-alpha.1"
   dependencies:
-    "@babel/runtime": ^7.23.9
-    "@mui/private-theming": ^5.15.14
-    "@mui/styled-engine": ^6.0.0-alpha.0
+    "@babel/runtime": ^7.24.4
+    "@mui/private-theming": ^6.0.0-alpha.1
+    "@mui/styled-engine": ^6.0.0-alpha.1
     "@mui/types": ^7.2.14
-    "@mui/utils": ^5.15.14
+    "@mui/utils": ^6.0.0-alpha.1
     clsx: ^2.1.0
     csstype: ^3.1.3
     prop-types: ^15.8.1
@@ -756,7 +943,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 4b59d430a4b4db8e0f620d434a5203c7d25c89291daddcfc53482874c197f6a1db99da2f1bb3256355ad1013efd6ec09455a829b0235ecba8229ace9375e36aa
+  checksum: adec269ba1cad8efc5dcdfcb354deb345b500b04090d7786e6d3f6e12d2704853b2f5b0fb069bdc1db74c5c4765fcfc324bb711a622f51dd06a8af2f1596371a
   languageName: node
   linkType: hard
 
@@ -787,6 +974,24 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 36543ba7e3b65fb3219ed27e8f1455aff15b47a74c9b642c63e60774e22baa6492a196079e72bcfa5a570421dab32160398f892110bd444428bcf8b266b11893
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.0.0-alpha.1":
+  version: 6.0.0-alpha.1
+  resolution: "@mui/utils@npm:6.0.0-alpha.1"
+  dependencies:
+    "@babel/runtime": ^7.24.4
+    "@types/prop-types": ^15.7.12
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 864ba88979448f8a7ee76d38402ceb45aed440daf89f50bc810085f87dad072d9efe9959b450fca4b8cfc09ff21f49f780e9acb2dc668e235510096aae6c7a03
   languageName: node
   linkType: hard
 
@@ -947,39 +1152,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "@octokit/core@npm:5.1.0"
+"@octokit/core@npm:^5.0.2":
+  version: 5.2.0
+  resolution: "@octokit/core@npm:5.2.0"
   dependencies:
     "@octokit/auth-token": ^4.0.0
-    "@octokit/graphql": ^7.0.0
-    "@octokit/request": ^8.0.2
-    "@octokit/request-error": ^5.0.0
-    "@octokit/types": ^12.0.0
+    "@octokit/graphql": ^7.1.0
+    "@octokit/request": ^8.3.1
+    "@octokit/request-error": ^5.1.0
+    "@octokit/types": ^13.0.0
     before-after-hook: ^2.2.0
     universal-user-agent: ^6.0.0
-  checksum: 170d16f5577df484116238ce04e2dbd6b45d8e96b4680fee657ae22fcafb311af8df8a14ae80610f41c1a85493c927910698019a761914ff4b0323ddbabcc9a4
+  checksum: 57d5f02b759b569323dcb76cc72bf94ea7d0de58638c118ee14ec3e37d303c505893137dd72918328794844f35c74b3cd16999319c4b40d410a310d44a9b7566
   languageName: node
   linkType: hard
 
-"@octokit/endpoint@npm:^9.0.0":
-  version: 9.0.4
-  resolution: "@octokit/endpoint@npm:9.0.4"
+"@octokit/endpoint@npm:^9.0.1":
+  version: 9.0.5
+  resolution: "@octokit/endpoint@npm:9.0.5"
   dependencies:
-    "@octokit/types": ^12.0.0
+    "@octokit/types": ^13.1.0
     universal-user-agent: ^6.0.0
-  checksum: ed1b64a448f478e5951a043ef816d634a5a1f584519cbf2f374ceac058f82a16e52f078f156aa8b8cbcab7b0590348d94294fc83c9b4eebd42a820a5f10db81c
+  checksum: d5cc2df9bd4603844c163eea05eec89c677cfe699c6f065fe86b83123e34554ec16d429e8142dec1e2b4cf56591ef0ce5b1763f250c87bc8e7bf6c74ba59ae82
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "@octokit/graphql@npm:7.0.2"
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@octokit/graphql@npm:7.1.0"
   dependencies:
-    "@octokit/request": ^8.0.1
-    "@octokit/types": ^12.0.0
+    "@octokit/request": ^8.3.0
+    "@octokit/types": ^13.0.0
     universal-user-agent: ^6.0.0
-  checksum: 05a752c4c2d84fc2900d8e32e1c2d1ee98a5a14349e651cb1109d0741e821e7417a048b1bb40918534ed90a472314aabbda35688868016f248098925f82a3bfa
+  checksum: 7b2706796e0269fc033ed149ea211117bcacf53115fd142c1eeafc06ebc5b6290e4e48c03d6276c210d72e3695e8598f83caac556cd00714fc1f8e4707d77448
   languageName: node
   linkType: hard
 
@@ -990,7 +1195,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^9.0.0":
+"@octokit/openapi-types@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@octokit/openapi-types@npm:22.0.1"
+  checksum: f361764bf965081bb94facc33a171a98c4d94285e5c218ca6355a5aea35d1ec732ab7fa7ac941034ca249601d768cfa5205bcbef0980c0c6faa2b842efeed2ec
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^9.1.5":
   version: 9.2.1
   resolution: "@octokit/plugin-paginate-rest@npm:9.2.1"
   dependencies:
@@ -1010,7 +1222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-rest-endpoint-methods@npm:^10.0.0":
+"@octokit/plugin-rest-endpoint-methods@npm:^10.2.0":
   version: 10.4.1
   resolution: "@octokit/plugin-rest-endpoint-methods@npm:10.4.1"
   dependencies:
@@ -1021,47 +1233,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request-error@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "@octokit/request-error@npm:5.0.1"
+"@octokit/request-error@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@octokit/request-error@npm:5.1.0"
   dependencies:
-    "@octokit/types": ^12.0.0
+    "@octokit/types": ^13.1.0
     deprecation: ^2.0.0
     once: ^1.4.0
-  checksum: a681341e43b4da7a8acb19e1a6ba0355b1af146fa0191f2554a98950cf85f898af6ae3ab0b0287d6c871f5465ec57cb38363b96b5019f9f77ba6f30eca39ede5
+  checksum: 2cdbb8e44072323b5e1c8c385727af6700e3e492d55bc1e8d0549c4a3d9026914f915866323d371b1f1772326d6e902341c872679cc05c417ffc15cadf5f4a4e
   languageName: node
   linkType: hard
 
-"@octokit/request@npm:^8.0.1, @octokit/request@npm:^8.0.2":
-  version: 8.2.0
-  resolution: "@octokit/request@npm:8.2.0"
+"@octokit/request@npm:^8.3.0, @octokit/request@npm:^8.3.1":
+  version: 8.4.0
+  resolution: "@octokit/request@npm:8.4.0"
   dependencies:
-    "@octokit/endpoint": ^9.0.0
-    "@octokit/request-error": ^5.0.0
-    "@octokit/types": ^12.0.0
+    "@octokit/endpoint": ^9.0.1
+    "@octokit/request-error": ^5.1.0
+    "@octokit/types": ^13.1.0
     universal-user-agent: ^6.0.0
-  checksum: 24dd2c96769aa52df19fdbf4058dfd06dc3a799121250c10ec5fbea4c43ec0183639a2beccc84053df2c298c18892ed8fbf722f1ca5271003feaac5290272beb
+  checksum: 3d937e817a85c0adf447ab46b428ccd702c31b2091e47adec90583ec2242bd64666306fe8188628fb139aa4752e19400eb7652b0f5ca33cd9e77bbb2c60b202a
   languageName: node
   linkType: hard
 
 "@octokit/rest@npm:^20.0.2":
-  version: 20.0.2
-  resolution: "@octokit/rest@npm:20.0.2"
+  version: 20.1.0
+  resolution: "@octokit/rest@npm:20.1.0"
   dependencies:
-    "@octokit/core": ^5.0.0
-    "@octokit/plugin-paginate-rest": ^9.0.0
+    "@octokit/core": ^5.0.2
+    "@octokit/plugin-paginate-rest": ^9.1.5
     "@octokit/plugin-request-log": ^4.0.0
-    "@octokit/plugin-rest-endpoint-methods": ^10.0.0
-  checksum: 5c56ac23f063a5375ae5a0609e6477d90afac872eccd07002870f9dd62755037282a74c15c90c848b76b64ea4b5af52f32720b8a1b7b133e758118d11d2c0e34
+    "@octokit/plugin-rest-endpoint-methods": ^10.2.0
+  checksum: 2d705cbc30eb12a0b6d75e7c8feed8c10e85fea98b1a6199a347fe751176bc7b5ca346fe874110fe4f350cec9a140a43a01b03d65c79b1adf2c5528ce1524c94
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^12.0.0, @octokit/types@npm:^12.6.0":
+"@octokit/types@npm:^12.6.0":
   version: 12.6.0
   resolution: "@octokit/types@npm:12.6.0"
   dependencies:
     "@octokit/openapi-types": ^20.0.0
   checksum: 850235f425584499a2266d5c585c1c2462ae11e25c650567142f3342cb9ce589c8c8fed87705811ca93271fd28c68e1fa77b88b67b97015d7b63d269fa46ed05
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0":
+  version: 13.4.0
+  resolution: "@octokit/types@npm:13.4.0"
+  dependencies:
+    "@octokit/openapi-types": ^22.0.1
+  checksum: 71d1e61e82ca10cb7f9e79d15158b7a9e84a6fe815fa865e7adbafee225963a18919316d7f0d7c96bc9e6751cf0f1663da056da468e8d5cebcbdaf44316cafba
   languageName: node
   linkType: hard
 
@@ -1124,269 +1345,269 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ast@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ast@npm:0.98.0"
+"@swagger-api/apidom-ast@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ast@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-error": ^0.98.0
+    "@swagger-api/apidom-error": ^0.99.0
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     unraw: ^3.0.0
-  checksum: 2b1dbbb6c2f01e0b23f619b8d7b32618a3721a45355513163eda595d91aa6df0b075c79bcf897e432bf1bf040042e26cc9d90b05c9a42d2a6a3f2181a9f63093
+  checksum: 48288eb46edb03040e9afec47762d826d8c343ee6a3216d54d65f21ad3e62daade6c8edf228d1ab9bff8f23163841f9ce8170951cf211bf1a2c08e52137293b0
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-core@npm:>=0.98.0 <1.0.0, @swagger-api/apidom-core@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-core@npm:0.98.0"
+"@swagger-api/apidom-core@npm:>=0.99.0 <1.0.0, @swagger-api/apidom-core@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-core@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-ast": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
+    "@swagger-api/apidom-ast": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
     "@types/ramda": ~0.29.6
     minim: ~0.23.8
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     short-unique-id: ^5.0.2
     stampit: ^4.3.2
-  checksum: 96b7b8f007223649c4b3c06355367a2864ceda6d548a6f8385ec495f73f194a781b5345c3a23d8684e546e3624a68d7bba99716ea5b7ef473a2796474668c679
+  checksum: f4313d6971e65feeaa6581a82dc3e720af87358e470c6dde0d11d8ae5b7d251cc430a2f70a88eebd251dd6c454a5708b61b9daf9f5d00fcbb1ce9d280874d5cc
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-error@npm:>=0.98.0 <1.0.0, @swagger-api/apidom-error@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-error@npm:0.98.0"
+"@swagger-api/apidom-error@npm:>=0.99.0 <1.0.0, @swagger-api/apidom-error@npm:^0.99.0":
+  version: 0.99.0
+  resolution: "@swagger-api/apidom-error@npm:0.99.0"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-  checksum: ddd289834afc971dab707ecfa3b435fd39d96298c63fb405381c8f17af54a457ba1d67f46f319253586d9f7096388847bd718d06b130693691eae1df55e4605d
+  checksum: 06d3da38ff9501376d2de3240d1a5023110482e053766c389f734a587dfd4c10b6ba695268edc58ce649284fd8e04a1f57484ae49dba210dcc5764df33fd52a0
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-json-pointer@npm:>=0.98.0 <1.0.0, @swagger-api/apidom-json-pointer@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-json-pointer@npm:0.98.0"
+"@swagger-api/apidom-json-pointer@npm:>=0.99.0 <1.0.0, @swagger-api/apidom-json-pointer@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-json-pointer@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 1f2801ed2e68a6529c0da86cf3dccadb433a96d6d01f2237e3f2cd494d015b8980eddbbbfa966f5443c7fc9674e80cf2544cec55f176cfa2ccb10a6ea26f84ae
+  checksum: d566f7410d3600766f7130a23da811b4c7a3a1542ab173f2b0b6578b01dcb531c61d1d43da5e944ef1d4059c47b6f472ee3ad55da625e672c1c1dd7315941689
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-api-design-systems@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:0.98.0"
+"@swagger-api/apidom-ns-api-design-systems@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-1": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-ns-openapi-3-1": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: 2dcf880f8af5b7cdc315ad3fbf4ec31c6fa2998e7bb067ccbf1eb84c69d0bea74275efb58c19f9b2ca54fffe15963772bc51c929562a1d912417108cc0c71f83
+  checksum: 22ce1af89437b104005158ded9b8237511f1d6dae9f564fb1c336e6f842898fde9dca8549aa94dc0724c03df51b4a33b7e081f79b5c44e68ab625d76a4589d47
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-asyncapi-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:0.98.0"
+"@swagger-api/apidom-ns-asyncapi-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-json-schema-draft-7": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-json-schema-draft-7": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: cf505b661f07cce43e221613e385652ceb2fe7884f5642aabcc79d7cd4cd9f5dc6a0778b7057a585976bb6792ef6d7e0e62196e49b083c2ccf23374d9a1917f7
+  checksum: d1759ca24f238ae833a34128e8672f972f8cca61ddbd9660e277bc8ad3d78b835e1b7406a97e8eed4946e526ce7ec8ed1debd79edaaf504fae86c92534cb0875
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-4@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:0.98.0"
+"@swagger-api/apidom-ns-json-schema-draft-4@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-ast": ^0.98.0
-    "@swagger-api/apidom-core": ^0.98.0
+    "@swagger-api/apidom-ast": ^0.99.1
+    "@swagger-api/apidom-core": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     stampit: ^4.3.2
-  checksum: 430059561fc5a4a96384564c1bf62c702d57fdd87fb39541c7348756468c554554e6162893be496b5f196e0ee30e4a607fa29d38106dd1fe9e4729dad99ffe88
+  checksum: 1b6c034e94287de0bea11a5f1c62de7b833436918cf961f38a12d877cf6de3caf3080fd38f0244905ea3b2fe8bb178a26c29ec631b4638ac46b597b992c7640a
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-6@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:0.98.0"
+"@swagger-api/apidom-ns-json-schema-draft-6@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     stampit: ^4.3.2
-  checksum: 616c45a1e6716e76706cf0ddf15d64bc4f59f6e7e791f07a391c04247f4e8bd068034e18377fff12a70cef8dc7d9da7a24a70207cfeb2411ae5d440735fdc6bd
+  checksum: e521ac3aec57f4239cce89641c7dc3555b2986ef23c6e9a15462d0b3015e54d89b0802546c313f5a91a2e5f94c8c570c417fe22034da57049bf49c61fc4e3592
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-7@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:0.98.0"
+"@swagger-api/apidom-ns-json-schema-draft-7@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-ns-json-schema-draft-6": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-ns-json-schema-draft-6": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     stampit: ^4.3.2
-  checksum: 3aceb145e6ccf0a6a2ac700797938b5ec940cf60bf7c4459312a109e0d57a92c658c65c28cf6b73c7854833b0b91f4ba8e3fe2154e2774c22873f6ebedd2182a
+  checksum: 791df6981518d239fdee2ae76bd9abf2542322e36785d2153fe2d4dcc1e6b2fdbb430ac9becb55734fc7968f77570895d5c9113f5aa59f0cc3c59ed3ed604b41
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-openapi-2@npm:0.98.0"
+"@swagger-api/apidom-ns-openapi-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-openapi-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: 86e902c50719285ccf84df42603072d3d63ba6b4c7b27695178c38e72e5536745daadd3a38f43e2baf428513dd0df87a38c56d395495543f7873b150bab426df
+  checksum: 8222aaffa9d1472ca2f876a361bbb888bc39b888d4600d9bd06ada7d9b516104391fbba9f51305ea0f522d0ae44370134631fc9492461483fad3cf757fa70b75
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-3-0@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:0.98.0"
+"@swagger-api/apidom-ns-openapi-3-0@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-ns-json-schema-draft-4": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: 2d4e11b5db078669aceb9ccb7a42784363b22fb63f228121ba7d2806247df2b777392717cc18c6ce4520d95d40b2e802ca63cf6efe6a85e83f28e360b085a53c
+  checksum: 8b5150e317e79795bc73a4a0c53860de4ab50e9e8fd9895d21d4a204e6ecee626477107e06df51aaef0e3651fdb2e48f197b5c8a0c33464b38d74abdffda0b60
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-3-1@npm:>=0.98.0 <1.0.0, @swagger-api/apidom-ns-openapi-3-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:0.98.0"
+"@swagger-api/apidom-ns-openapi-3-1@npm:>=0.99.0 <1.0.0, @swagger-api/apidom-ns-openapi-3-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-ast": ^0.98.0
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-0": ^0.98.0
+    "@swagger-api/apidom-ast": ^0.99.1
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-0": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: 9b8a1422bfa2ec4001ba62e8972098ba46f160837383210f28b67592c11b57d26ccc2fb795997cd8c4e46b5082001e4e9a7fb97f5deca461f245c5340c2a384f
+  checksum: 64d97f6569c68982af5e2933e52060a5b404a270ad45689209f57e049776a4d3e2062f89474eb26a2689bc08014a6d69d45c6d48c496e67b2664e7bf80356232
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-workflows-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-ns-workflows-1@npm:0.98.0"
+"@swagger-api/apidom-ns-workflows-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-ns-workflows-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-1": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-1": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.1.1
     ts-mixer: ^6.0.3
-  checksum: c53966c25412614c9cbef85dc121d0952a1dfb53edf9b8c8e5a845e6fce7cc30fa69cf612ac64cf2d4c792ea7562c1e859c0499a6c205121b752897084b460cd
+  checksum: 53ab8bd15d382648c701bb1e374d0ccc8e9d90a1aeb0106631d77846b765e3dd282e7b3d7f2b748f2eaccaf0d16ec02a49e3319078e298b1c228d22625934e1b
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-api-design-systems": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-api-design-systems": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 047c9fd0f707b12e5b25ad62dcd715dc5631186b1816956d2da13d5ba449a206921562a2c12a7444bf409fe915c3458d9bdd0b0a62d92e6f1bc3debae6552259
+  checksum: 406e4168c09e8907ac8983aecdc18429cded4db2b9793d2eb56a8e8494cae96d4309787c6316e3b584ad9c71434c0b31a933ee91d5b610b6fac72880692cfa3a
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-api-design-systems": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-api-design-systems": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 7fc7d3ee70e8a69a6a51f72cfb7e548f347408979102ffff7f3a7f55fd76fd8c5e96e7a77790f883ef51ab0f2a0e586878501245347d576f2260d0a01b7e7239
+  checksum: 899d2181efd0afdfda5eb9d678b7ae4e1f4710b2d56a05272751aec86510c0e48d681d8cb16388b8e88f225fbb63c9a0b49aa79b94589a82c1bdb41d66d77012
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-asyncapi-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-asyncapi-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: a4cdb8e7deb0dfdbe0b5e2be18748bb3b25b2c5e76309137d6389bc77cf2dc4c1f3d81822ebb796003f1c03cffe5bba28f44be865801b22eb8dabf64a67c93c6
+  checksum: e2b2d38769a11ad5c578a501acb8a015c8c359f7623ad37226d14845c96efd8d50d8d0bda417789402e74d52cbaf75c5e659936380b444f26dcfa5bb8c5df2df
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-asyncapi-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-asyncapi-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 67747cf47f0f6fb4326d14542ed5d5507c2b07407337fb89352003f3900400d4c3e453afedafe0668f145be31085f78d610d774c2a48ab88d6e07ff5e8499c28
+  checksum: 27f8e1486f41074b679dd0016fd8b764ba2ec11fd589438e10f6c712f9d816b9b45edb3de02315fe43dcbbafdd68f392e217855109919b9b75d5065885691e7e
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-json@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-json@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-json@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-json@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-ast": ^0.98.0
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
+    "@swagger-api/apidom-ast": ^0.99.1
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
     "@types/ramda": ~0.29.6
     node-gyp: latest
     ramda: ~0.29.1
@@ -1394,138 +1615,138 @@ __metadata:
     tree-sitter: =0.20.4
     tree-sitter-json: =0.20.2
     web-tree-sitter: =0.20.3
-  checksum: b054ce5ebc65362d55eb72c96ae180eb81c8c51dc6ad3e3dcd70ddd1dde448c511da22f6de415086d3bedc6f7b7a6e41505bba085b39a6a7d8fc3e40ca0190ab
+  checksum: eb8383965c866a60b06ea3da8f7a25a18fde35ae0455df8ce2a5a537b95424fba01cb3dd4f403869a3ba14d685388dc6f0b1362e5cf95ad6cdd1c65bd31dfa49
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: b423696bc61e29f4686c1456ace571a076c3296e651dd3b24d399ccc547b38ab20f1e21019ab9106645891d41b8e845175b4fd99afb97371d6311c0352ea211c
+  checksum: 4711cc0c42c7e31c82a45e15c118ddec5a8c0da628e1bc43c8096b849f2f56ff45e96d9ae32efb3f6d586b094cba1e068a5c42ff4bb99ffeba99389d4d865458
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-0": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-0": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: f591c73addd001cdf6e0654e1481118af24d5da4a629433ae6d63f82cc99b5007b5751f36453da876c39ad039f9d189122671e43dfc9f29bd2038e9a905344a8
+  checksum: 0e5146fcd49c5aae257b148420358bd136863df7261cfb5a338bb12bd86503c71bcb12cb510e5bff9a3dd84783ce8ed6776ac9300bc0c4e795c1ecb45fac91d0
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 24b311b750995c80943901426ea0c197a19b7a5be520256da7ee9bc788e5211c4ffc99126a2bc964099d4206a71943798631b7f4ef348a3289302a90438d91ae
+  checksum: e36e808ce1d79279cc495327e0223922071be3856603a485980f9a237af37dc3488c96e20b0b0d4f364b8a0247574185d61be1b6d536f06e49a8e91a3b262a1e
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 7cb19d4e843f8f71e91f9cc2c73ff8193ddae36067366b05c9e5953a4b038d1106b84e65868d8b8eb1b5b3fc9b68002ca298b5a1c824b2581458b156b2ba67cf
+  checksum: ec0156285810a76148f16bcb525ac8267ea99bc7c7a3ded7bb5dfdef987ab11c5d9fe20f5e1d43e35e0de777b68a0fd38633247bbe2ee66d05d76753f25f61e9
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-0": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-0": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 99ae7b028c538459b887e301b0b2ffd78eae505a1c7d44215a7480bef86db3eb5769a4ea502ce0d5f76257bf5f660c309a66c71898fea291a15d7a3d68aeb218
+  checksum: 397cf17638246ce6b4b4a7ddb315d78dfa50c565b399ff73f929ed64c6d8d991f3a4e38aa2b0ae70af6e5fa6fef06bae9205e9547649a957f3b5e4696ff0a050
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 04b47ccb03cdd72c88aa9b4ef78a055e582cb363ae4cc0dd5c126ad58c30b9650bf616788871be8781ed7eba22fdb043352a251abb727ec5f3828e11e344359e
+  checksum: 186f37d84758adcd02ba2d7734b5c99cc97f57dd102d1f2c82991bb7b68380a1a9d632656389262dfd20b53234a55ca8fa17e800c0401544abb90ace174bf1cf
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-workflows-json-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-workflows-json-1@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-workflows-json-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-workflows-json-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-workflows-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-workflows-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: c9c16fd980e96339804b782d58409681b3c819d8d5b67d4f214013b4d5e454d1aecef6a0b9e94b91abf0718e33422550b8e3284c31995b00c35ca6ec6431e862
+  checksum: 3a2e928be611461a9533eb69eebabd8bf59381e82507725c938e36dd77fead3c260d27cd287d92f884323928683e518c47361889c52720a58294c0b3eb2a7b55
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-workflows-yaml-1@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-ns-workflows-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-ns-workflows-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     ramda: ~0.29.1
     ramda-adjunct: ^4.0.0
-  checksum: 8a234fda22f54bbf1187edcca4f7e6e05c1b45c970f74cc2cdc89783288e2f011e263dfba18e3e339b75f041d4691428f6247ff8b3811f3494b517a0c0872c3f
+  checksum: 7869ba27343a8936ff2def5570b41b9abb2618afa8ee0fbecbb0a0213031dbbc28bb5692e486350748099fadd22578928f8d5a420f11769247044a026c8138e5
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^0.98.0":
-  version: 0.98.0
-  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:0.98.0"
+"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^0.99.1":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-ast": ^0.98.0
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
+    "@swagger-api/apidom-ast": ^0.99.1
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
     "@types/ramda": ~0.29.6
     node-gyp: latest
     ramda: ~0.29.1
@@ -1533,37 +1754,37 @@ __metadata:
     tree-sitter: =0.20.4
     tree-sitter-yaml: =0.5.0
     web-tree-sitter: =0.20.3
-  checksum: 318e02babded9b0dee7a3bf9be4819047a1688b35f8740d7915a9c31760c53d9976d6ecbb8eedc59c9cf747a446e588ae8423b86efce159f3846585aad5cc982
+  checksum: c10237864c4a99a319f5b19bb6c4234e32b422c03fc358350e9c9106a8612839abcc68e3e06e58ee2f9b450e1d7ab0288f8b89ee8b5338735170af1b48b2112a
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-reference@npm:>=0.98.0 <1.0.0":
-  version: 0.98.3
-  resolution: "@swagger-api/apidom-reference@npm:0.98.3"
+"@swagger-api/apidom-reference@npm:>=0.99.0 <1.0.0":
+  version: 0.99.1
+  resolution: "@swagger-api/apidom-reference@npm:0.99.1"
   dependencies:
     "@babel/runtime-corejs3": ^7.20.7
-    "@swagger-api/apidom-core": ^0.98.0
-    "@swagger-api/apidom-error": ^0.98.0
-    "@swagger-api/apidom-json-pointer": ^0.98.0
-    "@swagger-api/apidom-ns-asyncapi-2": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-2": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-0": ^0.98.0
-    "@swagger-api/apidom-ns-openapi-3-1": ^0.98.0
-    "@swagger-api/apidom-ns-workflows-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-json": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-json-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-workflows-json-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-workflows-yaml-1": ^0.98.0
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.98.0
+    "@swagger-api/apidom-core": ^0.99.1
+    "@swagger-api/apidom-error": ^0.99.0
+    "@swagger-api/apidom-json-pointer": ^0.99.1
+    "@swagger-api/apidom-ns-asyncapi-2": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-2": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-0": ^0.99.1
+    "@swagger-api/apidom-ns-openapi-3-1": ^0.99.1
+    "@swagger-api/apidom-ns-workflows-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-json": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-json-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-workflows-json-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-workflows-yaml-1": ^0.99.1
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ^0.99.1
     "@types/ramda": ~0.29.6
     axios: ^1.4.0
     minimatch: ^7.4.3
@@ -1614,7 +1835,7 @@ __metadata:
       optional: true
     "@swagger-api/apidom-parser-adapter-yaml-1-2":
       optional: true
-  checksum: 40b6e68075871e8ef4cc7aae1dbc1e8a4685e2747f2679f9da9efb1406573bd291b6cc67f795705450d980d0c81568ecef2a1fb2588a385cedc02e6bfc5933a1
+  checksum: 2131dc3df89c1670d8f5fde91f524a240afc253cf4fa8cf3c4b0ed2a35671b20b44fe944c7f3149fecd17e0cce3502f9d333df982d01ca999149a05bd9d9fc12
   languageName: node
   linkType: hard
 
@@ -1696,11 +1917,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 20.12.3
-  resolution: "@types/node@npm:20.12.3"
+  version: 20.12.7
+  resolution: "@types/node@npm:20.12.7"
   dependencies:
     undici-types: ~5.26.4
-  checksum: 982544a014391f214d36e5d65d8879f4d3ca9ed2258a5db76b1475a58858b5468ca1c65973e1a3e578f7665ed881af1ff9387d2d3e99e7a4d315994570fc50ff
+  checksum: 7cc979f7e2ca9a339ec71318c3901b9978555257929ef3666987f3e447123bc6dc92afcc89f6347e09e07d602fde7d51bcddea626c23aa2bb74aeaacfd1e1686
   languageName: node
   linkType: hard
 
@@ -1741,7 +1962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0, @types/prop-types@npm:^15.7.11":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0, @types/prop-types@npm:^15.7.11, @types/prop-types@npm:^15.7.12":
   version: 15.7.12
   resolution: "@types/prop-types@npm:15.7.12"
   checksum: ac16cc3d0a84431ffa5cfdf89579ad1e2269549f32ce0c769321fdd078f84db4fbe1b461ed5a1a496caf09e637c0e367d600c541435716a55b1d9713f5035dfe
@@ -1767,12 +1988,12 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*":
-  version: 18.2.74
-  resolution: "@types/react@npm:18.2.74"
+  version: 18.2.75
+  resolution: "@types/react@npm:18.2.75"
   dependencies:
     "@types/prop-types": "*"
     csstype: ^3.0.2
-  checksum: 093c0e350552e61393e2ba30169aa620e2e64c1e2d0ff38efd2a7549ded689b6ab6bffb65fe0f7ef9e143174de54442d942bd70c014649f464c52465701208d8
+  checksum: f77322720744beba6650462c0d75ccc0be27c176bd7b2aff32039ea30e498a78fe6dbce4a1c3fdbf592ccc01286059f332a294a3b6975dbb0d8d5999718ece38
   languageName: node
   linkType: hard
 
@@ -2406,18 +2627,17 @@ __metadata:
   linkType: hard
 
 "bare-fs@npm:^2.1.1":
-  version: 2.2.2
-  resolution: "bare-fs@npm:2.2.2"
+  version: 2.2.3
+  resolution: "bare-fs@npm:2.2.3"
   dependencies:
     bare-events: ^2.0.0
-    bare-os: ^2.0.0
     bare-path: ^2.0.0
     streamx: ^2.13.0
-  checksum: 5b6d26690ee4de93b559f6a1187b6ff553224fe4faea5ef9cbd235b13e033ef96a598dc28eb10aad17d1f35baed24e14e18436534041913f905a0c50ed27713a
+  checksum: 598f1998f08b19c7f1eea76291e5c93664c82b60b997e56aa0e6dea05193d74d3865cfe1172d05684893253ef700ce3abb4e76c55da799fed2ee7a82597a5c44
   languageName: node
   linkType: hard
 
-"bare-os@npm:^2.0.0, bare-os@npm:^2.1.0":
+"bare-os@npm:^2.1.0":
   version: 2.2.1
   resolution: "bare-os@npm:2.2.1"
   checksum: 7d870d8955531809253dfbceeda5b68e8396ef640166f8ff6c4c5e344f18a6bc9253f6d5e7d9ae2841426b66e9b7b1a39b2a102e6b23e1ddff26ad8a8981af81
@@ -2425,11 +2645,11 @@ __metadata:
   linkType: hard
 
 "bare-path@npm:^2.0.0, bare-path@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "bare-path@npm:2.1.0"
+  version: 2.1.1
+  resolution: "bare-path@npm:2.1.1"
   dependencies:
     bare-os: ^2.1.0
-  checksum: 03f260e72bd0ae0df4cd712322a2d3c8c16701ffaa55cf2d517ae62b7f78c64b7ec5bba81ec579367f966472481f5160db282e6663bd0fc8cfb09ebe272d8bba
+  checksum: f25710be4ee4106f15b405b85ceea5c8da799f803b237008dc4a3533c0db01acd2500742f2204a37909c6871949725fb1907cf95434d80710bf832716d0da8df
   languageName: node
   linkType: hard
 
@@ -2468,13 +2688,6 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
-  languageName: node
-  linkType: hard
-
-"bignumber.js@npm:9.0.0":
-  version: 9.0.0
-  resolution: "bignumber.js@npm:9.0.0"
-  checksum: 51f37890bca58bded63720add832b1c4898cf5b8ad95b5d4d9c3e763c461163d0355d11d91b740b0216b02e4e8cbb02455b28ee32140b775d96a39bbd817fdf6
   languageName: node
   linkType: hard
 
@@ -2608,9 +2821,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001579":
-  version: 1.0.30001605
-  resolution: "caniuse-lite@npm:1.0.30001605"
-  checksum: 8af1ae364c4f4c0796e7fd1aa195dfae2d9c3011c61f0907030201e4fc31a12e81407a13cca621a3b7f6a1eb0217ee9c681fb15670074c204a54edfab798d5c9
+  version: 1.0.30001608
+  resolution: "caniuse-lite@npm:1.0.30001608"
+  checksum: 7ae62689ca358cd3bdb89b2db9b4841812299f8a0b3ab94b52e4548778bd5740814617c0e0b2504b6bfaf47acc2472e1730393bd2027d646acbe8dc8206ad9e7
   languageName: node
   linkType: hard
 
@@ -2878,6 +3091,13 @@ __metadata:
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
   checksum: e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
+  languageName: node
+  linkType: hard
+
+"commander@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "commander@npm:12.0.0"
+  checksum: bce9e243dc008baba6b8d923f95b251ad115e6e7551a15838d7568abebcca0fc832da1800cf37caf37852f35ce4b7fb794ba7a4824b88c5adb1395f9268642df
   languageName: node
   linkType: hard
 
@@ -3228,14 +3448,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:=3.0.11":
-  version: 3.0.11
-  resolution: "dompurify@npm:3.0.11"
-  checksum: aefb86fbaa2cc6acda1a75ea918f69043689cb726f2932e5c1c3c85904255fd145230d66f0a9493ed27d64d035e990f3a767d99d73b1ae7c0b297782be230658
+"dompurify@npm:=3.1.0":
+  version: 3.1.0
+  resolution: "dompurify@npm:3.1.0"
+  checksum: 06fc76607cd076e394b2ea5479ab6f0407b8fedb6877ae95e94207b878365e5e1cd914055dacce152a5f419818afb8d4cd284b780246cf35363f0747c179a0ba
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.3":
+"dotenv@npm:^16.0.3, dotenv@npm:^16.4.5":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 301a12c3d44fd49888b74eb9ccf9f07a1f5df43f489e7fcb89647a2edcd84c42d6bc349dc8df099cd18f07c35c7b04685c1a4f3e6a6a9e6b30f8d48c15b7f49c
@@ -3481,6 +3701,86 @@ __metadata:
     is-date-object: ^1.0.1
     is-symbol: ^1.0.2
   checksum: 4ead6671a2c1402619bdd77f3503991232ca15e17e46222b0a41a5d81aebc8740a77822f5b3c965008e631153e9ef0580540007744521e72de8e33599fca2eed
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.19.10":
+  version: 0.19.12
+  resolution: "esbuild@npm:0.19.12"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.19.12
+    "@esbuild/android-arm": 0.19.12
+    "@esbuild/android-arm64": 0.19.12
+    "@esbuild/android-x64": 0.19.12
+    "@esbuild/darwin-arm64": 0.19.12
+    "@esbuild/darwin-x64": 0.19.12
+    "@esbuild/freebsd-arm64": 0.19.12
+    "@esbuild/freebsd-x64": 0.19.12
+    "@esbuild/linux-arm": 0.19.12
+    "@esbuild/linux-arm64": 0.19.12
+    "@esbuild/linux-ia32": 0.19.12
+    "@esbuild/linux-loong64": 0.19.12
+    "@esbuild/linux-mips64el": 0.19.12
+    "@esbuild/linux-ppc64": 0.19.12
+    "@esbuild/linux-riscv64": 0.19.12
+    "@esbuild/linux-s390x": 0.19.12
+    "@esbuild/linux-x64": 0.19.12
+    "@esbuild/netbsd-x64": 0.19.12
+    "@esbuild/openbsd-x64": 0.19.12
+    "@esbuild/sunos-x64": 0.19.12
+    "@esbuild/win32-arm64": 0.19.12
+    "@esbuild/win32-ia32": 0.19.12
+    "@esbuild/win32-x64": 0.19.12
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 2936e29107b43e65a775b78b7bc66ddd7d76febd73840ac7e825fb22b65029422ff51038a08d19b05154f543584bd3afe7d1ef1c63900429475b17fbe61cb61f
   languageName: node
   linkType: hard
 
@@ -3953,7 +4253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -3963,7 +4263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.3#~builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -4064,6 +4364,15 @@ __metadata:
     es-errors: ^1.3.0
     get-intrinsic: ^1.2.4
   checksum: e1cb53bc211f9dbe9691a4f97a46837a553c4e7caadd0488dc24ac694db8a390b93edd412b48dcdd0b4bbb4c595de1709effc75fc87c0839deedc6968f5bd973
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.2":
+  version: 4.7.3
+  resolution: "get-tsconfig@npm:4.7.3"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: d124e6900f8beb3b71f215941096075223158d0abb09fb5daa8d83299f6c17d5e95a97d12847b387e9e716bb9bd256a473f918fb8020f3b1acc0b1e5c2830bbf
   languageName: node
   linkType: hard
 
@@ -5322,7 +5631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"locter@npm:^2.0.2":
+"locter@npm:^2.1.0":
   version: 2.1.0
   resolution: "locter@npm:2.1.0"
   dependencies:
@@ -6292,8 +6601,8 @@ __metadata:
   linkType: hard
 
 "mysql2@npm:^3.6.1":
-  version: 3.9.3
-  resolution: "mysql2@npm:3.9.3"
+  version: 3.9.4
+  resolution: "mysql2@npm:3.9.4"
   dependencies:
     denque: ^2.1.0
     generate-function: ^2.3.1
@@ -6303,19 +6612,7 @@ __metadata:
     named-placeholders: ^1.1.3
     seq-queue: ^0.0.5
     sqlstring: ^2.3.2
-  checksum: 019bc209c551d3b68a4e93c3065e346b1bcf5989d7d795fb1e688938ae19a2469dec2d3b57a7798af5db9d7a2cc1660af187261b037b02698746c44e23480516
-  languageName: node
-  linkType: hard
-
-"mysql@npm:^2.18.1":
-  version: 2.18.1
-  resolution: "mysql@npm:2.18.1"
-  dependencies:
-    bignumber.js: 9.0.0
-    readable-stream: 2.3.7
-    safe-buffer: 5.1.2
-    sqlstring: 2.3.1
-  checksum: 430dec8525e849bbb53f78ffc7aa85b2d1535f49f96ae06064089219cfabfdb9b4051e1fabcbacc0e5b85174ae4c762b071b99d4fb4d062e98f90e723b1def0a
+  checksum: 2829f329cda58bfb97d24826242d9e05222a9ab2397b9746afe0c01a4801b18c685f75d268aa15f8b47988ed1ef50b28358ce6f9a69e18cb50d2c965d68b1a75
   languageName: node
   linkType: hard
 
@@ -7054,9 +7351,9 @@ __metadata:
   linkType: hard
 
 "property-information@npm:^6.0.0":
-  version: 6.4.1
-  resolution: "property-information@npm:6.4.1"
-  checksum: d9eece5f14b6fea9e6a1fa65fba88554956a58825eb9a5c8327bffee06bcc265117eaeae901871e8e8a5caec8d5e05ce39ab6872d5cef3b49a6f07815b6ef285
+  version: 6.5.0
+  resolution: "property-information@npm:6.5.0"
+  checksum: 6e55664e2f64083b715011e5bafaa1e694faf36986c235b0907e95d09259cc37c38382e3cc94a4c3f56366e05336443db12c8a0f0968a8c0a1b1416eebfc8f53
   languageName: node
   linkType: hard
 
@@ -7361,21 +7658,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:2.3.7":
-  version: 2.3.7
-  resolution: "readable-stream@npm:2.3.7"
-  dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~2.0.0
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.1.1
-    util-deprecate: ~1.0.1
-  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
@@ -7434,7 +7716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:^0.2.1":
+"reflect-metadata@npm:^0.2.1, reflect-metadata@npm:^0.2.2":
   version: 0.2.2
   resolution: "reflect-metadata@npm:0.2.2"
   checksum: a66c7b583e4efdd8f3c3124fbff33da2d0c86d8280617516308b32b2159af7a3698c961db3246387f56f6316b1d33a608f39bb2b49d813316dfc58f6d3bf3210
@@ -7712,6 +7994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 1012afc566b3fdb190a6309cc37ef3b2dcc35dff5fa6683a9d00cd25c3247edfbc4691b91078c97adc82a29b77a2660c30d791d65dab4fc78bfc473f60289977
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.19.0":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -7811,8 +8100,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@commander-js/extra-typings": ^12.0.1
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.11.0
+    "@faker-js/faker": ^8.4.1
     "@fontsource/inter": ^5.0.8
     "@fontsource/roboto": ^5.0.8
     "@monaco-editor/react": ^4.5.2
@@ -7834,7 +8125,9 @@ __metadata:
     "@typescript-eslint/parser": ^6.7.3
     "@uiw/react-md-editor": ^3.23.6
     bcrypt: ^5.1.1
+    commander: ^12.0.0
     discord.js: ^14.13.0
+    dotenv: ^16.4.5
     eslint: ^8.50.0
     eslint-config-prettier: ^9.0.0
     eslint-plugin-prettier: ^5.0.0
@@ -7847,7 +8140,6 @@ __metadata:
     marked: ^9.0.3
     marked-react: ^2.0.0
     monaco-editor: ^0.43.0
-    mysql: ^2.18.1
     mysql2: ^3.6.1
     next: ^14.0.4
     node-loader: ^2.0.0
@@ -7861,6 +8153,7 @@ __metadata:
     sass: ^1.69.3
     sharp: ^0.32.6
     swagger-ui-react: ^5.9.0
+    tsx: ^4.7.2
     typeorm: ^0.3.17
     typeorm-extension: ^3.0.2
     typeorm-naming-strategies: ^4.1.0
@@ -7900,17 +8193,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
-  version: 5.1.2
-  resolution: "safe-buffer@npm:5.1.2"
-  checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
-  languageName: node
-  linkType: hard
-
 "safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
   languageName: node
   linkType: hard
 
@@ -7933,15 +8226,15 @@ __metadata:
   linkType: hard
 
 "sass@npm:^1.69.3":
-  version: 1.72.0
-  resolution: "sass@npm:1.72.0"
+  version: 1.74.1
+  resolution: "sass@npm:1.74.1"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: f420079c7d51660b7256ee52463c1499ede36f7fd5c8ef50c687451777ad641509001454dea45244073cedd7c00e7a3bc1c362e55206ac6686171b994edb41e4
+  checksum: 3cbcd73d91e65607f7987656b7f6b0c6143724304544768079ecbe95505f1ce71036916e0e02dcc9923551c3779863bcdd522732a8f4409e89205271966a36f4
   languageName: node
   linkType: hard
 
@@ -8159,7 +8452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smob@npm:^1.4.0, smob@npm:^1.4.1":
+"smob@npm:^1.4.0, smob@npm:^1.5.0":
   version: 1.5.0
   resolution: "smob@npm:1.5.0"
   checksum: 436b99477ace208e44bd7cd7933532958acca507320724a8e57c730accc47c5d77e538fbc554ded145f1e3411ac0c4b55f6782bceaa5839671104fd68d4bdc7f
@@ -8178,12 +8471,12 @@ __metadata:
   linkType: hard
 
 "socks@npm:^2.7.1":
-  version: 2.8.1
-  resolution: "socks@npm:2.8.1"
+  version: 2.8.3
+  resolution: "socks@npm:2.8.3"
   dependencies:
     ip-address: ^9.0.5
     smart-buffer: ^4.2.0
-  checksum: 29586d42e9c36c5016632b2bcb6595e3adfbcb694b3a652c51bc8741b079c5ec37bdd5675a1a89a1620078c8137208294991fabb50786f92d47759a725b2b62e
+  checksum: 7a6b7f6eedf7482b9e4597d9a20e09505824208006ea8f2c49b71657427f3c137ca2ae662089baa73e1971c62322d535d9d0cf1c9235cf6f55e315c18203eadd
   languageName: node
   linkType: hard
 
@@ -8226,13 +8519,6 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
-  languageName: node
-  linkType: hard
-
-"sqlstring@npm:2.3.1":
-  version: 2.3.1
-  resolution: "sqlstring@npm:2.3.1"
-  checksum: de4299cf9bd0f49abae5b4eddde42c7ae7c447e035498ec50b3264610d6f0efbe433eeed2d20d48b6362bf46fd96c85cf6db240e994dbe6d5c3f9dac6d7ffd31
   languageName: node
   linkType: hard
 
@@ -8389,12 +8675,12 @@ __metadata:
   linkType: hard
 
 "stringify-entities@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "stringify-entities@npm:4.0.3"
+  version: 4.0.4
+  resolution: "stringify-entities@npm:4.0.4"
   dependencies:
     character-entities-html4: ^2.0.0
     character-entities-legacy: ^3.0.0
-  checksum: 59e8f523b403bf7d415690e72ae52982decd6ea5426bd8b3f5c66225ddde73e766c0c0d91627df082d0794e30b19dd907ffb5864cef3602e4098d6777d7ca3c2
+  checksum: ac1344ef211eacf6cf0a0a8feaf96f9c36083835b406560d2c6ff5a87406a41b13f2f0b4c570a3b391f465121c4fd6822b863ffb197e8c0601a64097862cc5b5
   languageName: node
   linkType: hard
 
@@ -8487,16 +8773,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swagger-client@npm:^3.26.4":
-  version: 3.26.4
-  resolution: "swagger-client@npm:3.26.4"
+"swagger-client@npm:^3.26.5":
+  version: 3.26.7
+  resolution: "swagger-client@npm:3.26.7"
   dependencies:
     "@babel/runtime-corejs3": ^7.22.15
-    "@swagger-api/apidom-core": ">=0.98.0 <1.0.0"
-    "@swagger-api/apidom-error": ">=0.98.0 <1.0.0"
-    "@swagger-api/apidom-json-pointer": ">=0.98.0 <1.0.0"
-    "@swagger-api/apidom-ns-openapi-3-1": ">=0.98.0 <1.0.0"
-    "@swagger-api/apidom-reference": ">=0.98.0 <1.0.0"
+    "@swagger-api/apidom-core": ">=0.99.0 <1.0.0"
+    "@swagger-api/apidom-error": ">=0.99.0 <1.0.0"
+    "@swagger-api/apidom-json-pointer": ">=0.99.0 <1.0.0"
+    "@swagger-api/apidom-ns-openapi-3-1": ">=0.99.0 <1.0.0"
+    "@swagger-api/apidom-reference": ">=0.99.0 <1.0.0"
     cookie: ~0.6.0
     deepmerge: ~4.3.0
     fast-json-patch: ^3.0.0-1
@@ -8506,21 +8792,21 @@ __metadata:
     node-fetch-commonjs: ^3.3.2
     qs: ^6.10.2
     traverse: ~0.6.6
-  checksum: 4abaf21013e9491005f2d186554305bbe438a9381b8baca5423d379a05e58fa35be9f59b858ba4016cabdeb5647d25366fccc90de3afcdd3b394abf5eb95e68a
+  checksum: 4f0e32859b7f045e3df59167bb2976e4daa918c1cd6e968e4f3bbc6241a2709475361b104cffa1311170da1b466b252d457d6b565afc6a6bd860b5129dcad624
   languageName: node
   linkType: hard
 
 "swagger-ui-react@npm:^5.9.0":
-  version: 5.13.0
-  resolution: "swagger-ui-react@npm:5.13.0"
+  version: 5.15.0
+  resolution: "swagger-ui-react@npm:5.15.0"
   dependencies:
-    "@babel/runtime-corejs3": ^7.24.1
+    "@babel/runtime-corejs3": ^7.24.4
     "@braintree/sanitize-url": =7.0.1
     base64-js: ^1.5.1
     classnames: ^2.5.1
     css.escape: 1.5.1
     deep-extend: 0.6.0
-    dompurify: =3.0.11
+    dompurify: =3.1.0
     ieee754: ^1.2.1
     immutable: ^3.x.x
     js-file-download: ^0.4.12
@@ -8543,7 +8829,7 @@ __metadata:
     reselect: ^5.1.0
     serialize-error: ^8.1.0
     sha.js: ^2.4.11
-    swagger-client: ^3.26.4
+    swagger-client: ^3.26.5
     url-parse: ^1.5.10
     xml: =1.0.1
     xml-but-prettier: ^1.0.1
@@ -8551,7 +8837,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0 <19"
     react-dom: ">=16.8.0 <19"
-  checksum: a772eda1f2d268124ffe3725d13ef554f307507b29d5a0910409114c67ccc695a9575df4319790322d9944ed673c65910307795ddd23fd958ba0642915a70d72
+  checksum: cacd3d64f49649d254f658a4868143c356fe106ec193ddcb483a254e997052a13619fababac23e4f939894ca586ba60970ecba9fba09b6c2c65f2c357b8bdfeb
   languageName: node
   linkType: hard
 
@@ -8697,9 +8983,13 @@ __metadata:
   linkType: hard
 
 "traverse@npm:~0.6.6":
-  version: 0.6.8
-  resolution: "traverse@npm:0.6.8"
-  checksum: ef22abfc73fe2052403093b6747febbfeb52dcf827db1ca0542a78932c918706b9b12c373ef27e1c3e07e3e92eb1c646b4fe97b936fe775d59cbce7da417e13b
+  version: 0.6.9
+  resolution: "traverse@npm:0.6.9"
+  dependencies:
+    gopd: ^1.0.1
+    typedarray.prototype.slice: ^1.0.3
+    which-typed-array: ^1.1.15
+  checksum: e2f4b46caf849b6ea9006230995edc7376c1361f33c2110f425339a814b71b968f5c84a130ae21b4300d1849fff42cec6117c2aebde8a68d33c6871e9621a80f
   languageName: node
   linkType: hard
 
@@ -8775,6 +9065,22 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "tsx@npm:4.7.2"
+  dependencies:
+    esbuild: ~0.19.10
+    fsevents: ~2.3.3
+    get-tsconfig: ^4.7.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 34c4fbbfb96848e05e39d5c55da51815f0856386428ad781a6df79e88ad62d83e9a071a3997a230ea7b45654cb215262267ac1202c31b67056359d386f6a9f65
   languageName: node
   linkType: hard
 
@@ -8855,25 +9161,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedarray.prototype.slice@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "typedarray.prototype.slice@npm:1.0.3"
+  dependencies:
+    call-bind: ^1.0.7
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.0
+    es-errors: ^1.3.0
+    typed-array-buffer: ^1.0.2
+    typed-array-byte-offset: ^1.0.2
+  checksum: 07bfebdfb7a67b2a80557bf4f1061d8a68ee847d7f04c91c7aa327aa90681f97e1ea3efef17b3b8f336a7f2da1d2ff95dd92de59a4788b4e6373318b27fca2c1
+  languageName: node
+  linkType: hard
+
 "typeorm-extension@npm:^3.0.2":
-  version: 3.5.0
-  resolution: "typeorm-extension@npm:3.5.0"
+  version: 3.5.1
+  resolution: "typeorm-extension@npm:3.5.1"
   dependencies:
     "@faker-js/faker": ^8.4.1
     consola: ^3.2.3
     envix: ^1.5.0
-    locter: ^2.0.2
+    locter: ^2.1.0
     pascal-case: ^3.1.2
     rapiq: ^0.9.0
-    reflect-metadata: ^0.2.1
-    smob: ^1.4.1
+    reflect-metadata: ^0.2.2
+    smob: ^1.5.0
     yargs: ^17.7.2
   peerDependencies:
     typeorm: ~0.3.0
   bin:
     typeorm-extension: bin/cli.cjs
     typeorm-extension-esm: bin/cli.mjs
-  checksum: 0deb452f80f1dca3253f19e290bb3475a8a0c2f3693e834e991969a622df24a0954a7d44b6e7eb237c9587b68b99eeb1f7a22c42965143cb228bf4ede11318dd
+  checksum: d8ee3cdcaf13c6cb0801b4b02552ef3b9d90744699161c90aef96d99a40e5121d6da98f5ba968eace6ea5e47392063edbf71ee6f877e4b61fd11ca2b3336a118
   languageName: node
   linkType: hard
 
@@ -8976,22 +9296,22 @@ __metadata:
   linkType: hard
 
 "typescript@npm:^5.2.2":
-  version: 5.4.3
-  resolution: "typescript@npm:5.4.3"
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d74d731527e35e64d8d2dcf2f897cf8cfbc3428be0ad7c48434218ba4ae41239f53be7c90714089db1068c05cae22436af2ecba71fd36ecc5e7a9118af060198
+  checksum: 53c879c6fa1e3bcb194b274d4501ba1985894b2c2692fa079db03c5a5a7140587a1e04e1ba03184605d35f439b40192d9e138eb3279ca8eee313c081c8bcd9b0
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
-  version: 5.4.3
-  resolution: "typescript@patch:typescript@npm%3A5.4.3#~builtin<compat/typescript>::version=5.4.3&hash=29ae49"
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=29ae49"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3a62fe90aa79d68c9ce38ea5edb2957e62801c733b99f0e5a2b8b50922761f68f7d9a40d28c544b449866e81185cddb93cba2496d0ff3fa52ef5b1f8bcace38c
+  checksum: 2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Here's a basic CLI to seed the database.  Could add more options but it works fine already.

```
$ yarn seed --help
Usage: seed [options]

CLI utility to seed the database

Options:
  -V, --version           output the version number
  -d, --drop              drop the database before executing (default: false)
  -u, --users <count>     how many users to create (default: 10)
  -m, --modules <count>   how many modules to create (default: 20)
  -r, --releases <count>  how many releases created per module (default: 10)
  -h, --help              display help for command
```

should partially resolve #2 